### PR TITLE
Run the startup scripts

### DIFF
--- a/elastic-mapping-updater-cli-image/pom.xml
+++ b/elastic-mapping-updater-cli-image/pom.xml
@@ -73,6 +73,7 @@
                                 <entryPoint>
                                     <arg>/tini</arg>
                                     <arg>--</arg>
+                                    <arg>/startup/startup.sh</arg>
                                     <arg>java</arg>
                                     <arg>-jar</arg>
                                     <arg>/maven/elastic-mapping-updater-cli-${project.version}.jar</arg>


### PR DESCRIPTION
The startup scripts may be necessary for establishing trust with Elasticsearch instances which are running on HTTPS.