### PR TITLE
US-539028: Update to latest java base image

### DIFF
--- a/elastic-mapping-updater-cli-image/pom.xml
+++ b/elastic-mapping-updater-cli-image/pom.xml
@@ -62,7 +62,7 @@
                         <image>
                             <name>${dockerCafDataProcessingOrg}elastic-mapping-updater${dockerProjectVersion}</name>
                             <build>
-                                <from>${dockerHubPublic}/cafapi/opensuse-jre11:3</from>
+                                <from>${dockerHubPublic}/cafapi/prereleases:opensuse-jre11-3.6.0-SNAPSHOT</from>
                                 <entryPoint>
                                     <arg>/tini</arg>
                                     <arg>--</arg>


### PR DESCRIPTION
'opensuse-jre11:3' opensuse version replaced by 'prereleases:opensuse-jre11-3.6.0-SNAPSHOT'