### PR TITLE
US952036: Oracle Linux Base Images: Update services to OracleLinux

### DIFF
--- a/elastic-mapping-updater-cli-image/pom.xml
+++ b/elastic-mapping-updater-cli-image/pom.xml
@@ -62,7 +62,7 @@
                         <image>
                             <name>${dockerCafDataProcessingOrg}elastic-mapping-updater${dockerProjectVersion}</name>
                             <build>
-                                <from>${projectDockerRegistry}/cafapi/opensuse-jre21</from>
+                                <from>${projectDockerRegistry}/cafapi/oraclelinux-jre21</from>
                                 <entryPoint>
                                     <arg>/tini</arg>
                                     <arg>--</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -355,9 +355,9 @@
                             <digest>sha256:ebd35d23f3201c82cd74e63b16025a6abbb3b93b9ddda2db854328104f2118ea</digest>
                         </image>
                         <image>
-                            <repository>${dockerHubPublic}/cafapi/opensuse-jre21</repository>
-                            <tag>4.1.0</tag>
-                            <digest>sha256:547758c42c0ec49654dd92447e5cc1e630b8df704d6898ddb8a8a3864a092967</digest>
+                            <targetRepository>cafapi/oraclelinux-jre21</targetRepository>
+                            <repository>${dockerHubPublic}/cafapi/prereleases</repository>
+                            <tag>oraclelinux-jre21-1.0.0-SNAPSHOT</tag>
                         </image>
                     </imageManagement>
                 </configuration>

--- a/release-notes-3.1.0.md
+++ b/release-notes-3.1.0.md
@@ -5,6 +5,6 @@ ${version-number}
 
 #### New Features
 - US929026: Updated to run on Java 21.
-- US952036: Image is now built on oraclelinux.
+- US952036: Image is now built on OracleLinux.
 
 #### Known Issues

--- a/release-notes-3.1.0.md
+++ b/release-notes-3.1.0.md
@@ -5,5 +5,6 @@ ${version-number}
 
 #### New Features
 - US929026: Updated to run on Java 21.
+- US952036: Image is now built on oraclelinux.
 
 #### Known Issues

--- a/release-notes-3.1.0.md
+++ b/release-notes-3.1.0.md
@@ -5,6 +5,6 @@ ${version-number}
 
 #### New Features
 - US929026: Updated to run on Java 21.
-- US952036: Image is now built on OracleLinux.
+- US952036: Image is now built on Oracle Linux.
 
 #### Known Issues


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=952036