### PR TITLE
Add missing <name> to pom.xml

### DIFF
--- a/elastic-mapping-updater-cli-image/pom.xml
+++ b/elastic-mapping-updater-cli-image/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>elastic-mapping-updater-cli-image</artifactId>
+    <name>elastic-mapping-updater-cli-image</name>
     <packaging>pom</packaging>
 
     <dependencies>

--- a/elastic-mapping-updater-cli-package/pom.xml
+++ b/elastic-mapping-updater-cli-package/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>elastic-mapping-updater-cli-package</artifactId>
+    <name>elastic-mapping-updater-cli-package</name>
     <packaging>pom</packaging>
 
     <dependencies>

--- a/elastic-mapping-updater-cli/pom.xml
+++ b/elastic-mapping-updater-cli/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>elastic-mapping-updater-cli</artifactId>
+    <name>elastic-mapping-updater-cli</name>
 
     <dependencies>
         <dependency>

--- a/elastic-mapping-updater/pom.xml
+++ b/elastic-mapping-updater/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>elastic-mapping-updater</artifactId>
+    <name>elastic-mapping-updater</name>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
This PR adds missing <name> tags to pom.xml files using their corresponding <artifactId> values, ensuring they're not added inside <parent> blocks.